### PR TITLE
Add option for skip when no licenses found for package

### DIFF
--- a/gocredits.go
+++ b/gocredits.go
@@ -36,10 +36,10 @@ func Run(argv []string, outStream, errStream io.Writer) error {
 	fs.SetOutput(errStream)
 	ver := fs.Bool("version", false, "display version")
 	var (
-		format        = fs.String("f", "", "format")
-		write         = fs.Bool("w", false, "write result to CREDITS file instead of stdout")
-		printJSON     = fs.Bool("json", false, "data to be printed in JSON format")
-		skipNoLicense = fs.Bool("skip-no-license", false, "skip when no licenses found for package")
+		format      = fs.String("f", "", "format")
+		write       = fs.Bool("w", false, "write result to CREDITS file instead of stdout")
+		printJSON   = fs.Bool("json", false, "data to be printed in JSON format")
+		skipMissing = fs.Bool("skip-missing", false, "skip when gocredits can't find the license")
 	)
 	if err := fs.Parse(argv); err != nil {
 		return err
@@ -51,7 +51,7 @@ func Run(argv []string, outStream, errStream io.Writer) error {
 	if modPath == "" {
 		modPath = "."
 	}
-	licenses, err := takeCredits(modPath, *skipNoLicense)
+	licenses, err := takeCredits(modPath, *skipMissing)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (ld *licenseDirs) set(l *licenseDir) {
 	ld.dirs[l.name] = dirs
 }
 
-func takeCredits(dir string, skipNoLicense bool) ([]*license, error) {
+func takeCredits(dir string, skipMissing bool) ([]*license, error) {
 	goroot, err := run("go", "env", "GOROOT")
 	if err != nil {
 		return nil, err
@@ -213,11 +213,11 @@ func takeCredits(dir string, skipNoLicense bool) ([]*license, error) {
 			break
 		}
 		if !found {
-			if skipNoLicense {
-				log.Printf("no licenses found for %q", packageName)
+			if skipMissing {
+				log.Printf("could not find the license for %q", packageName)
 				continue
 			}
-			return nil, fmt.Errorf("no licenses found for %q", packageName)
+			return nil, fmt.Errorf("could not find the license for %q", packageName)
 		}
 	}
 	return ret, nil

--- a/gocredits.go
+++ b/gocredits.go
@@ -239,7 +239,7 @@ func findLicense(dir string) (string, string, error) {
 		}
 	}
 	if fileName == "" {
-		return "", "", fmt.Errorf("no LICENSE files found in %q", dir)
+		return "", "", os.ErrNotExist
 	}
 	bs, err := ioutil.ReadFile(filepath.Join(dir, fileName))
 	if err != nil {

--- a/gocredits_test.go
+++ b/gocredits_test.go
@@ -30,20 +30,20 @@ func TestLicenseDirs_set(t *testing.T) {
 
 func TestTakeCredits(t *testing.T) {
 	tests := []struct {
-		name          string
-		dir           string
-		skipNoLicense bool
-		wantErr       error
+		name        string
+		dir         string
+		skipMissing bool
+		wantErr     error
 	}{
 		{"go.sub only", "gosum_only", false, nil},
 		{"go.mod only", "gomod_only", false, nil},
 		{"there is neither go.mod nor go.sum", "no_gomod_no_gosum", false, fmt.Errorf("use go modules")},
-		{"no licenses package found", "no_license", false, fmt.Errorf("no licenses found for \"github.com/Songmu/no_license_pkg\"")},
-		{"no licenses package found. but skip", "no_license", true, nil},
+		{"gocredits can't fild the license", "no_license", false, fmt.Errorf("could not find the license for \"github.com/Songmu/no_license_pkg\"")},
+		{"gocredits can't fild the license. but skip", "no_license", true, nil},
 	}
 	for _, tt := range tests {
 		dir := filepath.Join(testdataDir(), tt.dir)
-		_, gotErr := takeCredits(dir, tt.skipNoLicense)
+		_, gotErr := takeCredits(dir, tt.skipMissing)
 		if !reflect.DeepEqual(gotErr, tt.wantErr) {
 			t.Errorf("%s:\ngot  %v\nwant %v", tt.name, gotErr, tt.wantErr)
 		}

--- a/gocredits_test.go
+++ b/gocredits_test.go
@@ -1,6 +1,12 @@
 package gocredits
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
 
 func TestLicenseDirs_set(t *testing.T) {
 	ld := &licenseDirs{}
@@ -20,4 +26,32 @@ func TestLicenseDirs_set(t *testing.T) {
 	if len(ld.dirs["test"]) != 2 {
 		t.Errorf("len(ld.dirs[test]) should be 2 but: %d", len(ld.dirs["test"]))
 	}
+}
+
+func TestTakeCredits(t *testing.T) {
+	tests := []struct {
+		name          string
+		dir           string
+		skipNoLicense bool
+		wantErr       error
+	}{
+		{"go.sub only", "gosum_only", false, nil},
+		{"go.mod only", "gomod_only", false, nil},
+		{"there is neither go.mod nor go.sum", "no_gomod_no_gosum", false, fmt.Errorf("use go modules")},
+		{"no licenses package found", "no_license", false, fmt.Errorf("no licenses found for \"github.com/Songmu/no_license_pkg\"")},
+		{"no licenses package found. but skip", "no_license", true, nil},
+	}
+	for _, tt := range tests {
+		dir := filepath.Join(testdataDir(), tt.dir)
+		_, gotErr := takeCredits(dir, tt.skipNoLicense)
+		if !reflect.DeepEqual(gotErr, tt.wantErr) {
+			t.Errorf("%s:\ngot  %v\nwant %v", tt.name, gotErr, tt.wantErr)
+		}
+	}
+}
+
+func testdataDir() string {
+	wd, _ := os.Getwd()
+	dir, _ := filepath.Abs(filepath.Join(wd, "testdata"))
+	return dir
 }

--- a/testdata/gomod_only/go.mod
+++ b/testdata/gomod_only/go.mod
@@ -1,0 +1,1 @@
+module "github.com/owner/repo"

--- a/testdata/gomod_only/main.go
+++ b/testdata/gomod_only/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/testdata/gosum_only/go.sum
+++ b/testdata/gosum_only/go.sum
@@ -1,0 +1,2 @@
+github.com/Songmu/gocredits v0.1.0 h1:kvF4MYjGXpts+FhxlfmI15mHh0PApML9u7qQU91goYw=
+github.com/Songmu/gocredits v0.1.0/go.mod h1:5OhTh3YD/zUrdWAYuhMO2n3m7Ql+xRAnRLIGUEFABpQ=

--- a/testdata/gosum_only/main.go
+++ b/testdata/gosum_only/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/testdata/no_gomod_no_gosum/main.go
+++ b/testdata/no_gomod_no_gosum/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/testdata/no_license/go.sum
+++ b/testdata/no_license/go.sum
@@ -1,0 +1,2 @@
+github.com/Songmu/no_license_pkg v0.1.0 h1:kvF4MYjGXpts+FhxlfmI15mHh0PApML9u7qQU91goYw=
+github.com/Songmu/no_license_pkg v0.1.0/go.mod h1:5OhTh3YD/zUrdWAYuhMO2n3m7Ql+xRAnRLIGUEFABpQ=

--- a/testdata/no_license/main.go
+++ b/testdata/no_license/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Hi @Songmu !!

[I'm a heavy user of gocredits](https://github.com/search?q=gocredits+k1low&type=Code). Thank you for providing me with a useful tool !!

When gocredits has a package that can't find the license, it exits without outputting any license information.
So I took your advice and added an option to continue the license output process with just a warning message.

( If you have any other good ideas for option name, I'll change it )

Best regards.